### PR TITLE
Different stty check

### DIFF
--- a/PhpSerial.php
+++ b/PhpSerial.php
@@ -47,7 +47,7 @@ class PhpSerial
         if (substr($sysName, 0, 5) === "Linux") {
             $this->_os = "linux";
 
-            if ($this->_exec("stty --version") === 0) {
+            if ($this->_exec("which stty") === 0) {
                 register_shutdown_function(array($this, "deviceClose"));
             } else {
                 trigger_error(


### PR DESCRIPTION
Busybox's `stty` doesn't understand the `--version` flag yet is still perfectly capable of supporting usage in this project.

The fix for me was just to make sure an `stty` binary is available.

I know yours is a fork of the original repo, but you a have far more commits in the last 5 years so I thought I'd send the pull request to you in case you're interested. 